### PR TITLE
add `AsyncForth` VM variant supporting async builtin words

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,13 @@ edition = "2021"
 [dependencies]
 cfg-if = "1.0.0"
 hash32 = "0.3.1"
+futures-util = { version = "0.3.28", default-features = false, optional = true }
 
 [features]
 default = []
 use-std = []
 floats = []
+async = ["futures-util"]
 
 # [dependencies.serde]
 # version = "1.0.152"
@@ -22,3 +24,6 @@ floats = []
 # [dependencies.postcard]
 # version = "1.0.2"
 # default-features = false
+
+[dev-dependencies]
+futures = "0.3.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,5 @@ use-std = []
 floats = []
 async = ["futures-util"]
 
-# [dependencies.serde]
-# version = "1.0.152"
-# default-features = false
-# features = ["derive"]
-
-# [dependencies.postcard]
-# version = "1.0.2"
-# default-features = false
-
 [dev-dependencies]
 futures = "0.3.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,12 @@ edition = "2021"
 [dependencies]
 cfg-if = "1.0.0"
 hash32 = "0.3.1"
-futures-util = { version = "0.3.28", default-features = false, optional = true }
 
 [features]
 default = []
 use-std = []
 floats = []
-async = ["futures-util"]
+async = []
 
 [dev-dependencies]
 futures = "0.3.28"

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -16,6 +16,7 @@ pub enum EntryKind {
     StaticBuiltin,
     RuntimeBuiltin,
     Dictionary,
+    AsyncBuiltin(u8),
 }
 
 #[repr(C)]
@@ -48,6 +49,11 @@ pub struct DictionaryBump {
     pub(crate) start: *mut u8,
     pub(crate) cur: *mut u8,
     pub(crate) end: *mut u8,
+}
+
+pub trait DispatchAsync<T> {
+    type Future: core::future::Future<Output = Result<(), crate::Error>>;
+    fn dispatch_async(&self, id: u8, forth: &mut crate::Forth<T>) -> Self::Future;
 }
 
 impl<T: 'static> DictionaryEntry<T> {

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -16,7 +16,7 @@ pub enum EntryKind {
     StaticBuiltin,
     RuntimeBuiltin,
     Dictionary,
-    AsyncBuiltin(u8),
+    AsyncBuiltin,
 }
 
 #[repr(C)]
@@ -29,6 +29,8 @@ pub struct EntryHeader<T: 'static> {
 
 #[repr(C)]
 pub struct BuiltinEntry<T: 'static> {
+    // TODO(AJM): This should not be pub, if I decide to make async bis "special"
+    // ESPECIALLY if I rely on them being filled with "|| Err(())" functions
     pub hdr: EntryHeader<T>,
 }
 
@@ -53,7 +55,7 @@ pub struct DictionaryBump {
 
 pub trait DispatchAsync<T> {
     type Future: core::future::Future<Output = Result<(), crate::Error>>;
-    fn dispatch_async(&self, id: u8, forth: &mut crate::Forth<T>) -> Self::Future;
+    fn dispatch_async(&self, id: &FaStr, forth: &mut crate::Forth<T>) -> Self::Future;
 }
 
 impl<T: 'static> DictionaryEntry<T> {

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -59,9 +59,9 @@ pub struct DictionaryBump {
     pub(crate) end: *mut u8,
 }
 
-pub trait DispatchAsync<T> {
+pub trait DispatchAsync<'forth, T> {
     type Future: core::future::Future<Output = Result<(), crate::Error>>;
-    fn dispatch_async(&self, id: &FaStr, forth: &mut crate::Forth<T>) -> Self::Future;
+    fn dispatch_async(&self, id: &FaStr, forth: &'forth mut crate::Forth<T>) -> Self::Future;
 }
 
 impl<T: 'static> DictionaryEntry<T> {

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -17,6 +17,7 @@ pub enum EntryKind {
     StaticBuiltin,
     RuntimeBuiltin,
     Dictionary,
+    #[cfg(feature = "async")]
     AsyncBuiltin,
 }
 
@@ -35,6 +36,7 @@ pub struct BuiltinEntry<T: 'static> {
 }
 
 #[repr(C)]
+#[cfg(feature = "async")]
 pub struct AsyncBuiltinEntry<T: 'static> {
     pub hdr: EntryHeader<T>,
 }
@@ -59,6 +61,7 @@ pub struct DictionaryBump {
     pub(crate) end: *mut u8,
 }
 
+#[cfg(feature = "async")]
 pub trait DispatchAsync<'forth, T> {
     type Future: core::future::Future<Output = Result<(), crate::Error>>;
     fn dispatch_async(&self, id: &FaStr, forth: &'forth mut crate::Forth<T>) -> Self::Future;
@@ -177,10 +180,13 @@ pub mod test {
     use std::alloc::Layout;
 
     use crate::{
-        dictionary::{DictionaryBump, DictionaryEntry, BuiltinEntry, AsyncBuiltinEntry},
+        dictionary::{DictionaryBump, DictionaryEntry, BuiltinEntry},
         leakbox::LeakBox,
         Word,
     };
+
+    #[cfg(feature = "async")]
+    use super::AsyncBuiltinEntry;
 
     use super::EntryHeader;
 
@@ -188,6 +194,7 @@ pub mod test {
     fn sizes() {
         assert_eq!(size_of::<EntryHeader<()>>(), 3 * size_of::<usize>());
         assert_eq!(size_of::<BuiltinEntry<()>>(), 4 * size_of::<usize>());
+        #[cfg(feature = "async")]
         assert_eq!(size_of::<AsyncBuiltinEntry<()>>(), 3 * size_of::<usize>());
     }
 

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -35,6 +35,13 @@ pub struct BuiltinEntry<T: 'static> {
     pub func: WordFunc<T>,
 }
 
+/// A dictionary entry for an asynchronous builtin word.
+///
+/// This type is typically created using the [`async_builtin!`
+/// macro](crate::async_builtin), and is used with the
+/// [`AsyncForth`](crate::AsyncForth) VM type only. See the [documentation for
+/// `AsyncForth`](crate::AsyncForth) for details on using asynchronous builtin
+/// words.
 #[repr(C)]
 #[cfg(feature = "async")]
 pub struct AsyncBuiltinEntry<T: 'static> {
@@ -62,11 +69,112 @@ pub struct DictionaryBump {
 }
 
 #[cfg(feature = "async")]
-pub trait DispatchAsync<'forth, T: 'static> {
+/// A set of asynchronous builtin words, and a method to dispatch builtin names
+/// to [`Future`]s.
+///
+/// This trait is used along with the [`AsyncForth`] type to
+/// allow some builtin words to be implemented by `async fn`s (or [`Future`]s),
+/// rather than synchronous functions. See [here][async-vms] for an overview of
+/// how asynchronous Forth VMs work.
+///
+/// # Implementing Async Builtins
+///
+/// Synchronous builtins are provided to the Forth VM as a static slice of
+/// [`BuiltinEntry`]s. These entries allow the VM to lookup builtin words by
+/// name, and also contain a function pointer to the host function that
+/// implements that builtin. Asynchronous builtins work somewhat differently: a
+/// slice of [`AsyncBuiltinEntry`]s is still used in order to define the names
+/// of the asynchronous builtin words, but because asynchronous functions return
+/// a [`Future`] whose type must be known, an [`AsyncBuiltinEntry`] does *not*
+/// contain a function pointer to a host function. Instead, once the name of an
+/// async builtin is looked up, it is passed to the
+/// [`AsyncBuiltins::dispatch_async`] method, which returns the [`Future`]
+/// corresponding to that builtin function.
+///
+/// This indirection allows the `AsyncBuiltins` trait to erase the various
+/// [`Future`] types which are returned by the async builtin functions, allowing
+/// the [`AsyncForth`] VM to have only a single additional generic parameter for
+/// the `AsyncBuiltins` implementation itself. Without the indirection of
+/// [`dispatch_async`], the [`AsyncForth`] VM would need to be generic over
+/// *every* possible [`Future`] type that may be returned by an async builtin
+/// word, which would be impractical.[^1]
+///
+/// In order to erase multiple [`Future`] types, one of several approaches may
+/// be used:
+///
+/// - The [`Future`] returned by [`dispatch_async`] can be an [`enum`] of each
+///   builtin word's [`Future`] type. This requires all builtin words to be
+///   implemented as named [`Future`] types, rather than [`async fn`]s, but
+///   does not require heap allocation or unstable Rust features.
+/// - The [`Future`] type can be a `Pin<Box<dyn Future<Output = Result<(),
+///   Error>> + 'forth>`. This requires heap allocation, but can erase the type
+///   of any number of async builtin futures, which may be [`async fn`]s _or_
+///   named [`Future`] types.
+/// - If using nightly Rust, the
+///   [`#![feature(impl_trait_in_assoc_type)]`][63063] unstable feature can be
+///   enabled, allowing the [`AsyncBuiltins::Future`] associated type to be
+///   `impl Future<Output = Result(), Error> + 'forth`. This does not require
+///   heap allocation, and allows the [`dispatch_async`] method to return an
+///   [`async`] block [`Future`] which [`match`]es on the builtin's name and
+///   calls any number of [`async fn`]s or named [`Future`] types. This is the
+///   preferred approach when nightly features may be used.
+///
+/// Since the [`AsyncBuiltins`] trait is generic over the lifetime for which the
+/// [`Forth`] vm is borrowed mutably, the [`AsyncBuiltins::Future`] associated
+/// type may also be generic over that lifetime. This allows the returned
+/// [`Future`] to borrow the [`Forth`] VM so that its stacks can be mutated
+/// while the builtin [`Future`] executes (e.g. the result of the asynchronous
+/// operation can be pushed to the VM's `data` stack, et cetera).
+///
+/// [^1]: If the [`AsyncForth`] type was generic over every possible async
+///     builtin future, it would have a large number of generic type parameters
+///     which would all need to be filled in by the user. Additionally, because
+///     Rust does not allow a type to have a variadic number of generic
+///     parameters, there would have to be an arbitrary limit on the maximum
+///     number of async builtin words.
+///
+/// [`AsyncForth`]: crate::AsyncForth
+/// [`Future`]: core::future::Future
+/// [async-vms]: crate::AsyncForth#asynchronous-forth-vms
+/// [`async fn`]: https://doc.rust-lang.org/stable/std/keyword.async.html
+/// [`async`]: https://doc.rust-lang.org/stable/std/keyword.async.html
+/// [`dispatch_async`]: Self::dispatch_async
+/// [`enum`]: https://doc.rust-lang.org/stable/std/keyword.enum.html
+/// [`match`]: https://doc.rust-lang.org/stable/std/keyword.match.html
+/// [`Forth`]: crate::Forth
+/// [63063]: https://github.com/rust-lang/rust/issues/63063
+pub trait AsyncBuiltins<'forth, T: 'static> {
+    /// The [`Future`] type returned by [`Self::dispatch_async`].
+    ///
+    /// Since the `AsyncBuiltins` trait is generic over the lifetime of the
+    /// [`Forth`](crate::Forth) VM, the [`Future`] type may mutably borrow the
+    /// VM. This allows the VM's stacks to be mutated by the async builtin function.
+    ///
+    /// [`Future`]: core::future::Future
     type Future: core::future::Future<Output = Result<(), crate::Error>>;
 
-    const ASYNC_BUILTINS: &'static [AsyncBuiltinEntry<T>];
+    /// A static slice of [`AsyncBuiltinEntry`]s describing the builtins
+    /// provided by this implementation of `AsyncBuiltin`s.
+    ///
+    /// [`AsyncBuiltinEntry`]s may be created using the
+    /// [`async_builtin!`](crate::async_builtin) macro.
+    const BUILTINS: &'static [AsyncBuiltinEntry<T>];
 
+    /// Dispatch a builtin name (`id`) to an asynchronous builtin [`Future`].
+    ///
+    /// The returned [`Future`] may borrow the [`Forth`](crate::Forth) VM
+    /// provided as an argument to this function, allowing it to mutate the VM's
+    /// stacks as it executes.
+    ///
+    /// This method should return a [`Future`] for each builtin function
+    /// definition in [`Self::BUILTINS`]. Typically, this is implemented by
+    /// [`match`]ing the provided `id`, and returning the appropriate [`Future`]
+    /// for each builtin name. See [the `AsyncBuiltin` trait's
+    /// documentation][impling] for details on implementing this method.
+    ///
+    /// [`Future`]: core::future::Future
+    /// [`match`]: https://doc.rust-lang.org/stable/std/keyword.match.html
+    /// [impling]: #implementing-async-builtins
     fn dispatch_async(&self, id: &FaStr, forth: &'forth mut crate::Forth<T>) -> Self::Future;
 }
 

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -62,8 +62,11 @@ pub struct DictionaryBump {
 }
 
 #[cfg(feature = "async")]
-pub trait DispatchAsync<'forth, T> {
+pub trait DispatchAsync<'forth, T: 'static> {
     type Future: core::future::Future<Output = Result<(), crate::Error>>;
+
+    const ASYNC_BUILTINS: &'static [AsyncBuiltinEntry<T>];
+
     fn dispatch_async(&self, id: &FaStr, forth: &'forth mut crate::Forth<T>) -> Self::Future;
 }
 

--- a/src/leakbox.rs
+++ b/src/leakbox.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 #[cfg(feature = "async")]
-use crate::{AsyncForth, dictionary::{AsyncBuiltinEntry, DispatchAsync}};
+use crate::{AsyncForth, dictionary::{DispatchAsync}};
 
 // Helper type that will un-leak the buffer once it is dropped.
 pub struct LeakBox<T> {
@@ -137,12 +137,12 @@ impl<T: 'static> LBForth<T> {
 impl<T, D> AsyncLBForth<T, D>
 where
     T: 'static,
-    D: for<'forth> DispatchAsync<'forth, T>, {
+    D: for<'forth> DispatchAsync<'forth, T>,
+{
     pub fn from_params(
         params: LBForthParams,
         host_ctxt: T,
         sync_builtins: &'static [BuiltinEntry<T>],
-        async_builtins: &'static [AsyncBuiltinEntry<T>],
         dispatcher: D
     ) -> Self {
         let _payload_dstack: LeakBox<Word> = LeakBox::new(params.data_stack_elems);
@@ -164,7 +164,6 @@ where
                 output,
                 host_ctxt,
                 sync_builtins,
-                async_builtins,
                 dispatcher,
             )
             .unwrap()

--- a/src/leakbox.rs
+++ b/src/leakbox.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 #[cfg(feature = "async")]
-use crate::{AsyncForth, dictionary::{DispatchAsync}};
+use crate::{AsyncForth, dictionary::{AsyncBuiltins}};
 
 // Helper type that will un-leak the buffer once it is dropped.
 pub struct LeakBox<T> {
@@ -137,7 +137,7 @@ impl<T: 'static> LBForth<T> {
 impl<T, D> AsyncLBForth<T, D>
 where
     T: 'static,
-    D: for<'forth> DispatchAsync<'forth, T>,
+    D: for<'forth> AsyncBuiltins<'forth, T>,
 {
     pub fn from_params(
         params: LBForthParams,

--- a/src/leakbox.rs
+++ b/src/leakbox.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    dictionary::BuiltinEntry, input::WordStrBuf, output::OutputBuf, word::Word, CallContext, Forth,
+    dictionary::{BuiltinEntry, AsyncBuiltinEntry}, input::WordStrBuf, output::OutputBuf, word::Word, CallContext, Forth,
 };
 
 // Helper type that will un-leak the buffer once it is dropped.
@@ -82,7 +82,7 @@ impl<T: 'static> LBForth<T> {
         params: LBForthParams,
         host_ctxt: T,
         builtins: &'static [BuiltinEntry<T>],
-        async_builtins: &'static [BuiltinEntry<T>],
+        async_builtins: &'static [AsyncBuiltinEntry<T>],
     ) -> Self {
         let _payload_dstack: LeakBox<Word> = LeakBox::new(params.data_stack_elems);
         let _payload_rstack: LeakBox<Word> = LeakBox::new(params.return_stack_elems);

--- a/src/leakbox.rs
+++ b/src/leakbox.rs
@@ -82,6 +82,7 @@ impl<T: 'static> LBForth<T> {
         params: LBForthParams,
         host_ctxt: T,
         builtins: &'static [BuiltinEntry<T>],
+        async_builtins: &'static [BuiltinEntry<T>],
     ) -> Self {
         let _payload_dstack: LeakBox<Word> = LeakBox::new(params.data_stack_elems);
         let _payload_rstack: LeakBox<Word> = LeakBox::new(params.return_stack_elems);
@@ -102,6 +103,7 @@ impl<T: 'static> LBForth<T> {
                 output,
                 host_ctxt,
                 builtins,
+                async_builtins,
             )
             .unwrap()
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,13 +319,13 @@ pub mod test {
     #[cfg(feature = "async")]
     #[test]
     fn async_forth() {
-        use crate::{dictionary::{DispatchAsync, AsyncBuiltinEntry}, fastr::FaStr, async_builtin, leakbox::AsyncLBForth};
+        use crate::{dictionary::{AsyncBuiltins, AsyncBuiltinEntry}, fastr::FaStr, async_builtin, leakbox::AsyncLBForth};
 
         struct TestAsyncDispatcher;
-        impl<'forth> DispatchAsync<'forth, TestContext> for TestAsyncDispatcher {
+        impl<'forth> AsyncBuiltins<'forth, TestContext> for TestAsyncDispatcher {
             type Future = CountingFut<'forth>;
 
-            const ASYNC_BUILTINS: &'static [AsyncBuiltinEntry<TestContext>] = &[
+            const BUILTINS: &'static [AsyncBuiltinEntry<TestContext>] = &[
                 async_builtin!("counter"),
             ];
 
@@ -370,12 +370,12 @@ pub mod test {
     #[cfg(feature = "async")]
     #[test]
     fn async_forth_not() {
-        use crate::{dictionary::{DispatchAsync, AsyncBuiltinEntry}, fastr::FaStr, leakbox::AsyncLBForth, AsyncForth};
+        use crate::{dictionary::{AsyncBuiltins, AsyncBuiltinEntry}, fastr::FaStr, leakbox::AsyncLBForth, AsyncForth};
 
         struct TestAsyncDispatcher;
-        impl<'forth> DispatchAsync<'forth, TestContext> for TestAsyncDispatcher {
+        impl<'forth> AsyncBuiltins<'forth, TestContext> for TestAsyncDispatcher {
             type Future = futures::future::Ready<Result<(), Error>>;
-            const ASYNC_BUILTINS: &'static [AsyncBuiltinEntry<TestContext>] = &[];
+            const BUILTINS: &'static [AsyncBuiltinEntry<TestContext>] = &[];
             fn dispatch_async(
                 &self,
                 _id: &FaStr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,13 +321,14 @@ pub mod test {
     fn async_forth() {
         use crate::{dictionary::{DispatchAsync, AsyncBuiltinEntry}, fastr::FaStr, async_builtin, leakbox::AsyncLBForth};
 
-        const ASYNC_BIS: &[AsyncBuiltinEntry<TestContext>] = &[
-            async_builtin!("counter"),
-        ];
-
         struct TestAsyncDispatcher;
         impl<'forth> DispatchAsync<'forth, TestContext> for TestAsyncDispatcher {
             type Future = CountingFut<'forth>;
+
+            const ASYNC_BUILTINS: &'static [AsyncBuiltinEntry<TestContext>] = &[
+                async_builtin!("counter"),
+            ];
+
             fn dispatch_async(
                 &self,
                 id: &FaStr,
@@ -348,7 +349,6 @@ pub mod test {
             LBForthParams::default(),
             TestContext::default(),
             Forth::<TestContext>::FULL_BUILTINS,
-            ASYNC_BIS,
             TestAsyncDispatcher,
         );
         let forth = &mut lbforth.forth;
@@ -370,11 +370,12 @@ pub mod test {
     #[cfg(feature = "async")]
     #[test]
     fn async_forth_not() {
-        use crate::{dictionary::{DispatchAsync}, fastr::FaStr, leakbox::AsyncLBForth, AsyncForth};
+        use crate::{dictionary::{DispatchAsync, AsyncBuiltinEntry}, fastr::FaStr, leakbox::AsyncLBForth, AsyncForth};
 
         struct TestAsyncDispatcher;
         impl<'forth> DispatchAsync<'forth, TestContext> for TestAsyncDispatcher {
             type Future = futures::future::Ready<Result<(), Error>>;
+            const ASYNC_BUILTINS: &'static [AsyncBuiltinEntry<TestContext>] = &[];
             fn dispatch_async(
                 &self,
                 _id: &FaStr,
@@ -388,7 +389,7 @@ pub mod test {
             LBForthParams::default(),
             TestContext::default(),
             Forth::<TestContext>::FULL_BUILTINS,
-        &[], TestAsyncDispatcher);
+            TestAsyncDispatcher);
         test_forth(&mut lbforth.forth, |forth| futures::executor::block_on(forth.process_line()), AsyncForth::vm_mut)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod leakbox;
 
 use core::ptr::NonNull;
 
-use dictionary::{BuiltinEntry, EntryHeader, EntryKind};
+use dictionary::{BuiltinEntry, EntryHeader, EntryKind, AsyncBuiltinEntry};
 
 pub use crate::vm::Forth;
 use crate::{
@@ -73,6 +73,7 @@ pub enum Error {
     // Not *really* an error - but signals that a function should be called
     // again. At the moment, only used for internal interpreter functions.
     PendingCallAgain,
+    NoAsyncInNonAsyncSteppa,
 }
 
 impl From<StackError> for Error {
@@ -211,7 +212,7 @@ pub enum Lookup<T: 'static> {
         bi: NonNull<BuiltinEntry<T>>,
     },
     Async {
-        bi: NonNull<BuiltinEntry<T>>,
+        bi: NonNull<AsyncBuiltinEntry<T>>,
     },
     LQuote,
     LParen,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,24 +271,24 @@ pub mod test {
         test_forth(|forth| forth.process_line())
     }
 
-    // #[cfg(feature = "async")]
-    // #[test]
-    // fn async_forth() {
-    //     use crate::dictionary::DispatchAsync;
+    #[cfg(feature = "async")]
+    #[test]
+    fn async_forth() {
+        use crate::{dictionary::DispatchAsync, fastr::FaStr};
 
-    //     struct TestAsyncDispatcher;
-    //     impl DispatchAsync<TestContext> for TestAsyncDispatcher {
-    //         type Future = futures::future::Ready<Result<(), Error>>;
-    //         fn dispatch_async(
-    //             &self,
-    //             _id: u8,
-    //             _forth: &mut Forth<TestContext>,
-    //         ) -> Self::Future {
-    //            todo!("eliza: actually test this...")
-    //         }
-    //     }
-    //     test_forth(|forth| futures::executor::block_on(forth.process_line_async(&TestAsyncDispatcher)))
-    // }
+        struct TestAsyncDispatcher;
+        impl DispatchAsync<TestContext> for TestAsyncDispatcher {
+            type Future = futures::future::Ready<Result<(), Error>>;
+            fn dispatch_async(
+                &self,
+                _id: &FaStr,
+                _forth: &mut Forth<TestContext>,
+            ) -> Self::Future {
+               todo!("eliza: actually test this...")
+            }
+        }
+        test_forth(|forth| futures::executor::block_on(forth.process_line_async(&TestAsyncDispatcher)))
+    }
 
     fn test_forth(mut process_line: impl FnMut(&mut Forth<TestContext>) -> Result<(), Error>) {
         let mut lbforth = LBForth::from_params(

--- a/src/vm/async_vm.rs
+++ b/src/vm/async_vm.rs
@@ -25,6 +25,21 @@ use super::*;
 /// `Future`s](AsyncBuiltins::dispatch_async). See the documentation for the
 /// [`AsyncBuiltins`] trait for details on providing async builtins.
 ///
+/// # Synchronous Builtins
+///
+/// An `AsyncForth` VM may also have synchronous builtin words. These behave
+/// identically to the synchronous builtins in a non-async [`Forth`] VM.
+/// Synchronous builtins should be used for any builtin word that does not
+/// require performing an asynchronous operation on the host, such as those
+/// which perform mathematical operations.
+/// 
+/// Synchronous builtins can be provided when the VM is constructed as a static
+/// slice of [`BuiltinEntry`]s. They may also be added at runtime using the
+/// [`AsyncForth::add_sync_builtin`] and
+/// [`AsyncForth::add_sync_builtin_static_name`] method. These methods are
+/// identical to the [`Forth::add_builtin`] and
+/// [`Forth::add_builtin_static_name`] methods.
+///
 /// [`Future`]: core::future::Future
 /// [`async fn`]: https://doc.rust-lang.org/stable/std/keyword.async.html
 /// [`.await`]: https://doc.rust-lang.org/stable/std/keyword.await.html

--- a/src/vm/async_vm.rs
+++ b/src/vm/async_vm.rs
@@ -19,10 +19,9 @@ where
         output: OutputBuf,
         host_ctxt: T,
         sync_builtins: &'static [BuiltinEntry<T>],
-        async_builtins: &'static [AsyncBuiltinEntry<T>],
         dispatcher: D,
     ) -> Result<Self, Error> {
-        let vm = Forth::new_async(dstack_buf, rstack_buf, cstack_buf, dict_buf, input, output, host_ctxt, sync_builtins, async_builtins)?;
+        let vm = Forth::new_async(dstack_buf, rstack_buf, cstack_buf, dict_buf, input, output, host_ctxt, sync_builtins, D::ASYNC_BUILTINS)?;
         Ok(Self { vm, dispatcher })
     }
 

--- a/src/vm/async_vm.rs
+++ b/src/vm/async_vm.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+pub struct AsyncForth<T: 'static, D> {
+    vm: Forth<T>,
+    dispatcher: D,
+}
+
+impl<T, D> AsyncForth<T, D>
+where
+    T: 'static,
+    D: for<'forth> DispatchAsync<'forth, T>,
+{
+    pub unsafe fn new(
+        dstack_buf: (*mut Word, usize),
+        rstack_buf: (*mut Word, usize),
+        cstack_buf: (*mut CallContext<T>, usize),
+        dict_buf: (*mut u8, usize),
+        input: WordStrBuf,
+        output: OutputBuf,
+        host_ctxt: T,
+        sync_builtins: &'static [BuiltinEntry<T>],
+        async_builtins: &'static [AsyncBuiltinEntry<T>],
+        dispatcher: D,
+    ) -> Result<Self, Error> {
+        let vm = Forth::new_async(dstack_buf, rstack_buf, cstack_buf, dict_buf, input, output, host_ctxt, sync_builtins, async_builtins)?;
+        Ok(Self { vm, dispatcher })
+    }
+
+    pub fn output(&self) -> &OutputBuf {
+        &self.vm.output
+    }
+
+    pub fn output_mut(&mut self) -> &mut OutputBuf {
+        &mut self.vm.output
+    }
+
+    pub fn input_mut(&mut self) -> &mut WordStrBuf {
+        &mut self.vm.input
+    }
+
+    pub fn add_sync_builtin_static_name(
+        &mut self,
+        name: &'static str,
+        bi: WordFunc<T>,
+    ) -> Result<(), Error> {
+        self.vm.add_builtin_static_name(name, bi)
+    }
+
+    pub fn add_sync_builtin(&mut self, name: &str, bi: WordFunc<T>) -> Result<(), Error> {
+        self.vm.add_builtin(name, bi)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn vm_mut(&mut self) -> &mut Forth<T> {
+        &mut self.vm
+    }
+
+    pub async fn process_line(&mut self) -> Result<(), Error> {
+        let res = async {
+            loop {
+                match self.vm.start_processing_line()? {
+                    ProcessAction::Done => {
+                        self.vm.output.push_str("ok.\n")?;
+                        break Ok(());
+                    },
+                    ProcessAction::Continue => {},
+                    ProcessAction::Execute =>
+                        while self.async_pig().await? != Step::Done {},
+                }
+            }
+        }.await;
+        match res {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                self.vm.data_stack.clear();
+                self.vm.return_stack.clear();
+                self.vm.call_stack.clear();
+                Err(e)
+            }
+        }
+    }
+
+    // Single step execution (async version).
+    async fn async_pig(&mut self) -> Result<Step, Error> {
+        let Self { ref mut vm, ref dispatcher } = self;
+
+        let top = match vm.call_stack.try_peek() {
+            Ok(t) => t,
+            Err(StackError::StackEmpty) => return Ok(Step::Done),
+            Err(e) => return Err(Error::Stack(e)),
+        };
+
+        let kind = unsafe { top.eh.as_ref().kind };
+        let res = unsafe { match kind {
+            EntryKind::StaticBuiltin => (top.eh.cast::<BuiltinEntry<T>>().as_ref().func)(vm),
+            EntryKind::RuntimeBuiltin => (top.eh.cast::<BuiltinEntry<T>>().as_ref().func)(vm),
+            EntryKind::Dictionary => (top.eh.cast::<DictionaryEntry<T>>().as_ref().func)(vm),
+            EntryKind::AsyncBuiltin => {
+                dispatcher.dispatch_async(&top.eh.as_ref().name, vm).await
+            },
+        }};
+
+        match res {
+            Ok(_) => {
+                let _ = vm.call_stack.pop();
+            }
+            Err(Error::PendingCallAgain) => {
+                // ok, just don't pop
+            }
+            Err(e) => return Err(e),
+        }
+
+        Ok(Step::NotDone)
+    }
+}

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -14,6 +14,7 @@ pub mod floats;
 // NOTE: This macro exists because we can't have const constructors that include
 // "mut" items, which unfortunately covers things like `fn(&mut T)`. Use a macro
 // until this is resolved.
+#[macro_export]
 macro_rules! builtin {
     ($name:literal, $func:expr) => {
         BuiltinEntry {
@@ -28,6 +29,21 @@ macro_rules! builtin {
     };
 }
 
+#[macro_export]
+macro_rules! async_builtin {
+    ($name:literal) => {
+        $crate::dictionary::AsyncBuiltinEntry {
+            hdr: $crate::dictionary::EntryHeader {
+                name: $crate::fastr::comptime_fastr($name),
+                kind: $crate::dictionary::EntryKind::AsyncBuiltin,
+                len: 0,
+                _pd: core::marker::PhantomData,
+            },
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! builtin_if_feature {
     ($feature:literal, $name:literal, $func:expr) => {
         #[cfg(feature = $feature)]

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -1,4 +1,4 @@
-use core::{fmt::Write, mem::size_of};
+use core::{fmt::Write, mem::size_of, marker::PhantomData};
 
 use crate::{
     dictionary::{BuiltinEntry, DictionaryEntry, EntryHeader, EntryKind},
@@ -19,10 +19,11 @@ macro_rules! builtin {
         BuiltinEntry {
             hdr: EntryHeader {
                 name: comptime_fastr($name),
-                func: $func,
                 kind: EntryKind::StaticBuiltin,
                 len: 0,
+                _pd: core::marker::PhantomData,
             },
+            func: $func,
         }
     };
 }
@@ -725,13 +726,14 @@ impl<T: 'static> Forth<T> {
                         unsafe {
                             dict_base.as_ptr().write(DictionaryEntry {
                                 hdr: EntryHeader {
-                                    // TODO: Should we look up `(interpret)` for consistency?
-                                    // Use `find_word`?
-                                    func: Self::interpret,
                                     name,
                                     kind: EntryKind::Dictionary,
                                     len,
+                                    _pd: PhantomData,
                                 },
+                                // TODO: Should we look up `(interpret)` for consistency?
+                                // Use `find_word`?
+                                func: Self::interpret,
                                 // Don't link until we know we have a "good" entry!
                                 link: self.run_dict_tail.take(),
                                 parameter_field: [],

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -29,6 +29,11 @@ macro_rules! builtin {
     };
 }
 
+/// Constructs an [`AsyncBuiltinEntry`](crate::dictionary::AsyncBuiltinEntry)
+/// for an asynchronous builtin word.
+///
+/// See the [documentation for `AsyncForth`](crate::AsyncForth) for details on
+/// using asynchronous builtin words.
 #[macro_export]
 macro_rules! async_builtin {
     ($name:literal) => {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -32,7 +32,7 @@ pub mod builtins;
 /// reasons.
 pub struct Forth<T: 'static> {
     mode: Mode,
-    pub(crate) data_stack: Stack<Word>,
+    pub data_stack: Stack<Word>,
     pub(crate) return_stack: Stack<Word>,
     pub(crate) call_stack: Stack<CallContext<T>>,
     pub(crate) dict_alloc: DictionaryBump,
@@ -281,6 +281,8 @@ impl<T> Forth<T> {
                     idx: 0,
                     len: 0,
                 })?;
+
+                return Ok(ProcessAction::Execute);
             },
             Lookup::Literal { val } => {
                 self.data_stack.push(Word::data(val))?;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -221,7 +221,7 @@ impl<T> Forth<T> {
     }
 
     #[cfg(feature = "async")]
-    pub async fn process_line_async(&mut self, dispatcher: &impl DispatchAsync<T>) -> Result<(), Error> {
+    pub async fn process_line_async(&mut self, dispatcher: &impl for<'forth> DispatchAsync<'forth, T>) -> Result<(), Error> {
         let res = async {
             loop {
                 match self.start_processing_line()? {
@@ -352,7 +352,7 @@ impl<T> Forth<T> {
 
     // Single step execution (async version).
     #[cfg(feature = "async")]
-    async fn async_pig(&mut self, dispatcher: &impl DispatchAsync<T>) -> Result<Step, Error> {
+    async fn async_pig(&mut self, dispatcher: &impl for<'forth> DispatchAsync<'forth, T>) -> Result<Step, Error> {
         let top = match self.call_stack.try_peek() {
             Ok(t) => t,
             Err(StackError::StackEmpty) => return Ok(Step::Done),

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 #[cfg(feature = "async")]
-use crate::dictionary::{AsyncBuiltinEntry, DispatchAsync};
+use crate::dictionary::{AsyncBuiltinEntry, AsyncBuiltins};
 
 pub mod builtins;
 


### PR DESCRIPTION
This branch adds a new `AsyncForth` type, which is a variant of the
`Forth` type that allows builtin words to be implemented by `async fn`s
or `Future`s in the host program. The `AsyncForth` type's `process_line`
method is an `async fn`, and it will yield when the Forth program
executing in the VM executes a builtin word which performs an async
operation. This allows multiple `AsyncForth` VMs to execute
asynchronously on the host, suspending when the Forth program must wait
for I/O or other operations which the host program can perform
asynchronously.

In order to implement asynchronous builtin words, a new trait, called
`AsyncBuiltins`, must be implemented by the user code and provided to
the VM. The documentation for the `AsyncBuiltins` trait discusses why
this is necessary and how it should be implemented.

The `AsyncForth` VM and related traits and types are feature flagged and
are only present when an "async" feature flag is enabled. This allows us
to avoid generating extra code used only for async execution when async
VMs are not in use.

New tests are also added for the `AsyncForth` VM, including a duplicate
of the existing test for `Forth` and a new test in which an async
builtin word executes and causes the executing VM to yield.