### PR TITLE
add `Dictionary::deep_copy`, misc refactors

### DIFF
--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -67,6 +67,12 @@ pub struct Dictionary<T: 'static> {
     pub(crate) tail: Option<NonNull<DictionaryEntry<T>>>,
 }
 
+pub(crate) struct EntryBuilder<'dict, T: 'static> {
+    dict: &'dict mut Dictionary<T>,
+    len: u16,
+    base: NonNull<DictionaryEntry<T>>,
+}
+
 pub(crate) struct DictionaryBump {
     pub(crate) start: *mut u8,
     pub(crate) cur: *mut u8,
@@ -227,18 +233,51 @@ impl<T: 'static> Dictionary<T> {
         Ok(())
     }
 
-    // /// # Safety
-    // /// 
-    // /// Base must be bump allocated by `self.alloc`.
-    // /// TODO(eliza): is there a way to make this method responsible for doing
-    // /// the allocation as well?
-    // pub(crate) unsafe fn write_entry(&mut self, base: NonNull<DictionaryEntry<T>>, hdr: EntryHeader<T>, )
+    pub(crate) fn build_entry(&mut self) -> Result<EntryBuilder<'_, T>, BumpError> {
+        let base = self.alloc.bump::<DictionaryEntry<T>>()?;
+        Ok(EntryBuilder {
+            base,
+            len: 0,
+            dict: self
+        })
+    }
 
     pub(crate) fn entries(&self) -> Entries<'_, T> {
         Entries {
             next: self.tail,
             _dict: PhantomData,
         }
+    }
+}
+
+impl<T> EntryBuilder<'_, T> {
+    pub(crate) fn write_word(mut self, word: Word) -> Result<Self, BumpError> {
+        self.dict.alloc.bump_write(word)?;
+        self.len += 1;
+        Ok(self)
+    }
+
+    pub(crate) fn finish(self, name: FaStr, func: WordFunc<T>) {
+        unsafe {
+            self.base.as_ptr().write(DictionaryEntry {
+                hdr: EntryHeader {
+                    name,
+                    kind: EntryKind::Dictionary,
+                    len: self.len,
+                    _pd: PhantomData
+                },
+                // TODO: Should arrays push length and ptr? Or just ptr?
+                //
+                // TODO: Should we look up `(variable)` for consistency?
+                // Use `find_word`?
+                func,
+
+                // Don't link until we know we have a "good" entry!
+                link: self.dict.tail.take(),
+                parameter_field: [],
+            });
+        }
+        self.dict.tail = Some(self.base);
     }
 }
 

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -203,6 +203,11 @@ impl<T: 'static> DictionaryEntry<T> {
         let pfp: *mut [Word; 0] = addr_of_mut!((*ptr).parameter_field);
         NonNull::new_unchecked(pfp.cast::<Word>())
     }
+
+    pub fn parameters(&self) -> &[Word] {
+        let pfp = self.parameter_field.as_ptr();
+        unsafe { core::slice::from_raw_parts(pfp, self.hdr.len as usize) }
+    }
 }
 
 impl<T: 'static> Dictionary<T> {
@@ -247,6 +252,59 @@ impl<T: 'static> Dictionary<T> {
             next: self.tail,
             _dict: PhantomData,
         }
+    }
+
+    /// Performs a deep copy of all entries in `self` into `other`.
+    ///
+    /// This is an *O*(*entries*) operation, as it traverses all entries in
+    /// `self` and constructs new entries in `other` with the same data. This
+    /// means that all pointers in the `other` dictionary should point into
+    /// `other`'s bump arena, rather than `self`'s. Changes to bindings in
+    /// `self` after a deep copy is performed will not effect bindings in
+    /// `other`, and changes to bindings in `other` will not effect the existing
+    /// bindings in `self`.
+    ///
+    /// # Errors
+    ///
+    /// This method returns an error if `other`'s bump arena lacks sufficient
+    /// capacity to store all the entries in `self`.
+    pub(crate) fn deep_copy(&self, other: &mut Self) -> Result<(), BumpError> {
+        // before doing a partial copy, check that other has room for everything
+        let remaining = other.alloc.capacity() - other.alloc.used();
+        if remaining < self.alloc.used() {
+            return Err(BumpError::OutOfMemory);
+        }
+
+        for entry in self.entries() {
+            debug_assert!(matches!(entry.hdr.kind, EntryKind::RuntimeBuiltin | EntryKind::Dictionary));
+            // TODO(eliza): i think this might be potentially wasteful if the
+            // entry's name came from a `'static str` rather than a runtime
+            // string...can we track that and avoid interning it into the new dict?
+            let name = other.alloc.bump_str(entry.hdr.name.as_str())?;
+
+            // NOTE(eliza): the capacity check means we should be able to unwrap
+            // this, I think, but whatever...
+            let base = other.alloc.bump::<DictionaryEntry<T>>()?;
+            for word in entry.parameters() {
+                other.alloc.bump_write(*word)?;
+            }
+            unsafe {
+                base.as_ptr().write(DictionaryEntry {
+                    hdr: EntryHeader {
+                        name,
+                        kind: entry.hdr.kind,
+                        len: entry.hdr.len,
+                        _pd: PhantomData,
+                    },
+                    func: entry.func,
+                    link: other.tail.take(),
+                    parameter_field: [],
+                });
+            }
+            other.tail = Some(base);
+        }
+
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,7 +394,7 @@ pub mod test {
     }
 
     fn test_forth<T>(forth: &mut T, process_line: impl Fn(&mut T) -> Result<(), Error>, get_forth: impl Fn(&mut T) -> &mut Forth<TestContext>) {
-        assert_eq!(0, get_forth(forth).dict_alloc.used());
+        assert_eq!(0, get_forth(forth).dict.alloc.used());
         let lines = &[
             ("2 3 + .", "5 ok.\n"),
             (": yay 2 3 + . ;", "ok.\n"),
@@ -485,7 +485,7 @@ pub mod test {
         // Uncomment if you want to check how much of the dictionary
         // was used during a test run.
         //
-        // assert_eq!(176, forth.dict_alloc.used());
+        // assert_eq!(176, forth.dict.alloc.used());
 
         // Uncomment this if you want to see the output of the
         // forth run. TODO: Remove this once we implement the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,105 @@ pub mod test {
         assert_eq!(&context.contents, &[6, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }
 
+    #[test]
+    fn it_still_works_when_deepcopied() {
+        // TODO(eliza): this could also be used in other tests..
+        fn test_lines(name: &str, forth: &mut Forth<TestContext>, lines: &[(&str, &str)]) {
+            for (line, out) in lines {
+                println!("{name}: {line}");
+                forth.input.fill(line).unwrap();
+                forth.process_line().unwrap();
+                print!("{name} => {}", forth.output.as_str());
+                assert_eq!(forth.output.as_str(), *out);
+                forth.output.clear();
+            }
+        }
+
+        let mut lbforth1 = LBForth::from_params(
+            LBForthParams::default(),
+            TestContext::default(),
+            Forth::<TestContext>::FULL_BUILTINS,
+        );
+
+        let forth1 = &mut lbforth1.forth;
+
+        // run all the tests on the first forth VM
+        println!("\n --- testing first forth VM --- \n");
+        test_lines("forth1", forth1, TEST_LINES);
+
+        // create a new forth VM, and deep copy the first VM's dictionary into
+        // the second.
+        let mut lbforth2 = LBForth::from_params(
+            LBForthParams::default(),
+            TestContext::default(),
+            Forth::<TestContext>::FULL_BUILTINS,
+        );
+
+        let forth2 = &mut lbforth2.forth;
+        forth1.dict.deep_copy(&mut forth2.dict).expect("deep copy should work");
+
+        let lines = &[
+            // all the bindings in the old VM's dictionary should be present in the
+            // new VM (and, it shouldn't segfault... :D)
+            ("yay yay yay", "5 5 5 ok.\n"),
+            ("boop", "5 5 ok.\n"),
+            ("0 err", "5 5 ok.\n"),
+            ("1 err", "5 5 5 5 5 5 ok.\n"),
+            ("0 erf", "5 5 ok.\n"),
+            ("1 erf", "5 5 5 5 5 5 5 5 ok.\n"),
+            ("  0 nif", "ok.\n"),
+            ("0 1 nif", "1 6 1 ok.\n"),
+            ("1 1 nif", "1 2 2 1 ok.\n"),
+            ("star star star", "***ok.\n"),
+            ("sloop", "1 **********6 ok.\n"),
+            ("count", "0 1 2 3 4 5 6 7 8 9 ok.\n"),
+            ("smod", "****ok.\n"),
+            ("beep", "hello, world!ok.\n"),
+            ("x .", "123 ok.\n"),
+            ("4 x + .", "127 ok.\n"),
+            // the existing `y` variable should have its second value from the
+            // first test.
+            ("y @ .", "10 ok.\n"),
+            // reassigning `y` is okay
+            ("100 y !", "ok.\n"),
+            ("y @ .", "100 ok.\n"),
+            // also reassign `a`
+            ("500 a !", "ok.\n"),
+            ("z @ . z 1 w+ @ . z 2 w+ @ . z 3 w+ @ .", "0 0 0 0 ok.\n"),
+            // define a new word in `forth2`.
+            (": star3 star star star ;", "ok.\n"),
+            ("star3", "***ok.\n"),
+            // define a new variable in forth2
+            ("variable foo", "ok.\n"),
+            ("foo @ .", "0 ok.\n"),
+            ("123 foo !", "ok.\n"),
+            ("foo @ .", "123 ok.\n"),
+        ];
+
+        println!("\n --- testing second forth VM --- \n");
+        test_lines("forth2", forth2, lines);
+
+        // check that forth1's bindings aren't clobbered
+        println!("\n --- retesting first VM's bindings --- \n");
+        test_lines("forth1", forth1, &[
+            // the existing `y` variable should have its second value from the
+            // first test.
+            ("y @ .", "10 ok.\n"),
+            ("a @ .", "100 ok.\n"),
+        ]);
+        // new words defined in forth2 don't exist in forth1
+        forth1.input.fill("star3").unwrap();
+        assert_eq!(forth1.process_line(), Err(Error::LookupFailed));
+        forth1.output.clear();
+        forth1.return_stack.clear();
+
+        // and neither do new variables.
+        forth1.input.fill("foo @ .").unwrap();
+        assert_eq!(forth1.process_line(), Err(Error::LookupFailed));
+        forth1.output.clear();
+        forth1.return_stack.clear();
+    }
+
     struct CountingFut<'forth> {
         target: usize,
         ctr: usize,
@@ -393,60 +492,61 @@ pub mod test {
         test_forth(&mut lbforth.forth, |forth| futures::executor::block_on(forth.process_line()), AsyncForth::vm_mut)
     }
 
+    const TEST_LINES: &[(&str, &str)]  = &[
+        ("2 3 + .", "5 ok.\n"),
+        (": yay 2 3 + . ;", "ok.\n"),
+        ("yay yay yay", "5 5 5 ok.\n"),
+        (": boop yay yay ;", "ok.\n"),
+        ("boop", "5 5 ok.\n"),
+        (": err if boop boop boop else yay yay then ;", "ok.\n"),
+        (": erf if boop boop boop then yay yay ;", "ok.\n"),
+        ("0 err", "5 5 ok.\n"),
+        ("1 err", "5 5 5 5 5 5 ok.\n"),
+        ("0 erf", "5 5 ok.\n"),
+        ("1 erf", "5 5 5 5 5 5 5 5 ok.\n"),
+        (": one 1 . ;", "ok.\n"),
+        (": two 2 . ;", "ok.\n"),
+        (": six 6 . ;", "ok.\n"),
+        (": nif if one if two two else six then one then ;", "ok.\n"),
+        ("  0 nif", "ok.\n"),
+        ("0 1 nif", "1 6 1 ok.\n"),
+        ("1 1 nif", "1 2 2 1 ok.\n"),
+        ("42 emit", "*ok.\n"),
+        (": star 42 emit ;", "ok.\n"),
+        ("star star star", "***ok.\n"),
+        (": sloop one 5 0 do star star loop six ;", "ok.\n"),
+        ("sloop", "1 **********6 ok.\n"),
+        (": count 10 0 do i . loop ;", "ok.\n"),
+        ("count", "0 1 2 3 4 5 6 7 8 9 ok.\n"),
+        (": smod 10 0 do i 3 mod not if star then loop ;", "ok.\n"),
+        ("smod", "****ok.\n"),
+        (": beep .\" hello, world!\" ;", "ok.\n"),
+        ("beep", "hello, world!ok.\n"),
+        ("constant x 123", "ok.\n"),
+        ("x .", "123 ok.\n"),
+        ("4 x + .", "127 ok.\n"),
+        ("variable y", "ok.\n"),
+        ("y @ .", "0 ok.\n"),
+        ("10 y !", "ok.\n"),
+        ("y @ .", "10 ok.\n"),
+        ("array z 4", "ok.\n"),
+        ("z @ . z 1 w+ @ . z 2 w+ @ . z 3 w+ @ .", "0 0 0 0 ok.\n"),
+        ("10 z ! 20 z 1 w+ ! 30 z 2 w+ ! 40 z 3 w+ !", "ok.\n"),
+        (
+            "z @ . z 1 w+ @ . z 2 w+ @ . z 3 w+ @ .",
+            "10 20 30 40 ok.\n",
+        ),
+        ("forget z", "ok.\n"),
+        ("variable a", "ok.\n"),
+        ("100 a !", "ok.\n"),
+        ("array z 4", "ok.\n"),
+        ("z @ . z 1 w+ @ . z 2 w+ @ . z 3 w+ @ .", "0 0 0 0 ok.\n"),
+    ];
+
     fn test_forth<T>(forth: &mut T, process_line: impl Fn(&mut T) -> Result<(), Error>, get_forth: impl Fn(&mut T) -> &mut Forth<TestContext>) {
         assert_eq!(0, get_forth(forth).dict.alloc.used());
-        let lines = &[
-            ("2 3 + .", "5 ok.\n"),
-            (": yay 2 3 + . ;", "ok.\n"),
-            ("yay yay yay", "5 5 5 ok.\n"),
-            (": boop yay yay ;", "ok.\n"),
-            ("boop", "5 5 ok.\n"),
-            (": err if boop boop boop else yay yay then ;", "ok.\n"),
-            (": erf if boop boop boop then yay yay ;", "ok.\n"),
-            ("0 err", "5 5 ok.\n"),
-            ("1 err", "5 5 5 5 5 5 ok.\n"),
-            ("0 erf", "5 5 ok.\n"),
-            ("1 erf", "5 5 5 5 5 5 5 5 ok.\n"),
-            (": one 1 . ;", "ok.\n"),
-            (": two 2 . ;", "ok.\n"),
-            (": six 6 . ;", "ok.\n"),
-            (": nif if one if two two else six then one then ;", "ok.\n"),
-            ("  0 nif", "ok.\n"),
-            ("0 1 nif", "1 6 1 ok.\n"),
-            ("1 1 nif", "1 2 2 1 ok.\n"),
-            ("42 emit", "*ok.\n"),
-            (": star 42 emit ;", "ok.\n"),
-            ("star star star", "***ok.\n"),
-            (": sloop one 5 0 do star star loop six ;", "ok.\n"),
-            ("sloop", "1 **********6 ok.\n"),
-            (": count 10 0 do i . loop ;", "ok.\n"),
-            ("count", "0 1 2 3 4 5 6 7 8 9 ok.\n"),
-            (": smod 10 0 do i 3 mod not if star then loop ;", "ok.\n"),
-            ("smod", "****ok.\n"),
-            (": beep .\" hello, world!\" ;", "ok.\n"),
-            ("beep", "hello, world!ok.\n"),
-            ("constant x 123", "ok.\n"),
-            ("x .", "123 ok.\n"),
-            ("4 x + .", "127 ok.\n"),
-            ("variable y", "ok.\n"),
-            ("y @ .", "0 ok.\n"),
-            ("10 y !", "ok.\n"),
-            ("y @ .", "10 ok.\n"),
-            ("array z 4", "ok.\n"),
-            ("z @ . z 1 w+ @ . z 2 w+ @ . z 3 w+ @ .", "0 0 0 0 ok.\n"),
-            ("10 z ! 20 z 1 w+ ! 30 z 2 w+ ! 40 z 3 w+ !", "ok.\n"),
-            (
-                "z @ . z 1 w+ @ . z 2 w+ @ . z 3 w+ @ .",
-                "10 20 30 40 ok.\n",
-            ),
-            ("forget z", "ok.\n"),
-            ("variable a", "ok.\n"),
-            ("100 a !", "ok.\n"),
-            ("array z 4", "ok.\n"),
-            ("z @ . z 1 w+ @ . z 2 w+ @ . z 3 w+ @ .", "0 0 0 0 ok.\n"),
-        ];
 
-        for (line, out) in lines {
+        for (line, out) in TEST_LINES {
             println!("{}", line);
             get_forth(forth).input.fill(line).unwrap();
             process_line(forth).unwrap();

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -185,8 +185,8 @@ impl<T: 'static> Forth<T> {
     ];
 
     pub fn dict_free(&mut self) -> Result<(), Error> {
-        let capa = self.dict_alloc.capacity();
-        let used = self.dict_alloc.used();
+        let capa = self.dict.alloc.capacity();
+        let used = self.dict.alloc.used();
         let free = capa - used;
         writeln!(
             &mut self.output,
@@ -221,19 +221,11 @@ impl<T: 'static> Forth<T> {
     }
 
     pub fn list_dict(&mut self) -> Result<(), Error> {
-        let Self {
-            run_dict_tail,
-            output,
-            ..
-        } = self;
+        let Self { output, dict, .. } = self;
         output.write_str("dictionary: ")?;
-        let mut cur = *run_dict_tail;
-
-        while let Some(item) = cur.take() {
-            let item = unsafe { item.as_ref() };
+        for item in dict.entries() {
             output.write_str(item.hdr.name.as_str())?;
             output.write_str(", ")?;
-            cur = item.link;
         }
         output.write_str("\n")?;
         Ok(())
@@ -322,21 +314,21 @@ impl<T: 'static> Forth<T> {
 
         // NOTE: We use the *name* pointer for rewinding, as we allocate the name before the item.
         let name_ptr = unsafe { defn.as_ref().hdr.name.as_ptr().cast_mut() };
-        self.run_dict_tail = unsafe { defn.as_ref().link };
+        self.dict.tail = unsafe { defn.as_ref().link };
         let addr = defn.as_ptr();
-        let name_contains = self.dict_alloc.contains(name_ptr.cast());
-        let contains = self.dict_alloc.contains(addr.cast());
-        let ordered = (addr as usize) <= (self.dict_alloc.cur as usize);
+        let name_contains = self.dict.alloc.contains(name_ptr.cast());
+        let contains = self.dict.alloc.contains(addr.cast());
+        let ordered = (addr as usize) <= (self.dict.alloc.cur as usize);
 
         if !(name_contains && contains && ordered) {
             return Err(Error::InternalError);
         }
 
-        let len = (self.dict_alloc.cur as usize) - (name_ptr as usize);
+        let len = (self.dict.alloc.cur as usize) - (name_ptr as usize);
         unsafe {
             name_ptr.write_bytes(0x00, len);
         }
-        self.dict_alloc.cur = name_ptr;
+        self.dict.alloc.cur = name_ptr;
         Ok(())
     }
 
@@ -727,14 +719,14 @@ impl<T: 'static> Forth<T> {
             .cur_word()
             .ok_or(Error::ColonCompileMissingName)?;
         let old_mode = core::mem::replace(&mut self.mode, Mode::Compile);
-        let name = self.dict_alloc.bump_str(name)?;
+        let name = self.dict.alloc.bump_str(name)?;
 
         // Allocate and initialize the dictionary entry
         //
         // TODO: Using `bump_write` here instead of just `bump` causes Miri to
         // get angry with a stacked borrows violation later when we attempt
         // to interpret a built word.
-        let dict_base = self.dict_alloc.bump::<DictionaryEntry<T>>()?;
+        let dict_base = self.dict.alloc.bump::<DictionaryEntry<T>>()?;
 
         let mut len = 0u16;
 
@@ -756,11 +748,11 @@ impl<T: 'static> Forth<T> {
                                 // Use `find_word`?
                                 func: Self::interpret,
                                 // Don't link until we know we have a "good" entry!
-                                link: self.run_dict_tail.take(),
+                                link: self.dict.tail.take(),
                                 parameter_field: [],
                             });
                         }
-                        self.run_dict_tail = Some(dict_base);
+                        self.dict.tail = Some(dict_base);
                         self.mode = old_mode;
                         return Ok(());
                     }

--- a/src/vm/builtins.rs
+++ b/src/vm/builtins.rs
@@ -726,6 +726,9 @@ impl<T: 'static> Forth<T> {
         // TODO: Using `bump_write` here instead of just `bump` causes Miri to
         // get angry with a stacked borrows violation later when we attempt
         // to interpret a built word.
+        // TODO(eliza): it's unfortunate we cannot easily use the "EntryBuilder"
+        // type here, as it must mutably borrow the dictionary, and `munch_one`
+        // must perform lookups...hmm...
         let dict_base = self.dict.alloc.bump::<DictionaryEntry<T>>()?;
 
         let mut len = 0u16;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -8,7 +8,7 @@ use core::{
 
 use crate::{
     dictionary::{
-        BuiltinEntry, BumpError, DictionaryBump, DictionaryEntry, EntryHeader, EntryKind,
+        BuiltinEntry, BumpError, Dictionary, DictionaryEntry, EntryHeader, EntryKind,
     },
     fastr::{FaStr, TmpFaStr},
     input::WordStrBuf,
@@ -40,21 +40,13 @@ pub struct Forth<T: 'static> {
     pub data_stack: Stack<Word>,
     pub(crate) return_stack: Stack<Word>,
     pub(crate) call_stack: Stack<CallContext<T>>,
-    pub(crate) dict_alloc: DictionaryBump,
-    run_dict_tail: Option<NonNull<DictionaryEntry<T>>>,
+    pub(crate) dict: Dictionary<T>,
     pub input: WordStrBuf,
     pub output: OutputBuf,
     pub host_ctxt: T,
     builtins: &'static [BuiltinEntry<T>],
     #[cfg(feature = "async")]
     async_builtins: &'static [AsyncBuiltinEntry<T>],
-}
-
-/// Iterator over a [`Forth`] VM's dictionary entries.
-struct DictEntries<'dict, T: 'static> {
-    next: Option<NonNull<DictionaryEntry<T>>>,
-    /// Ensure that the `DictEntries` is bound to the VM's lifetime.
-    _forth: PhantomData<&'dict Forth<T>>,
 }
 
 enum ProcessAction {
@@ -83,15 +75,14 @@ impl<T> Forth<T> {
         let data_stack = Stack::new(dstack_buf.0, dstack_buf.1);
         let return_stack = Stack::new(rstack_buf.0, rstack_buf.1);
         let call_stack = Stack::new(cstack_buf.0, cstack_buf.1);
-        let dict_alloc = DictionaryBump::new(dict_buf.0, dict_buf.1);
+        let dict = Dictionary::new(dict_buf.0, dict_buf.1);
 
         Ok(Self {
             mode: Mode::Run,
             data_stack,
             return_stack,
             call_stack,
-            dict_alloc,
-            run_dict_tail: None,
+            dict,
             input,
             output,
             host_ctxt,
@@ -117,15 +108,14 @@ impl<T> Forth<T> {
         let data_stack = Stack::new(dstack_buf.0, dstack_buf.1);
         let return_stack = Stack::new(rstack_buf.0, rstack_buf.1);
         let call_stack = Stack::new(cstack_buf.0, cstack_buf.1);
-        let dict_alloc = DictionaryBump::new(dict_buf.0, dict_buf.1);
+        let dict = Dictionary::new(dict_buf.0, dict_buf.1);
 
         Ok(Self {
             mode: Mode::Run,
             data_stack,
             return_stack,
             call_stack,
-            dict_alloc,
-            run_dict_tail: None,
+            dict,
             input,
             output,
             host_ctxt,
@@ -140,31 +130,13 @@ impl<T> Forth<T> {
         bi: WordFunc<T>,
     ) -> Result<(), Error> {
         let name = unsafe { FaStr::new(name.as_ptr(), name.len()) };
-        self.add_bi_fastr(name, bi)
+        self.dict.add_bi_fastr(name, bi)?;
+        Ok(())
     }
 
     pub fn add_builtin(&mut self, name: &str, bi: WordFunc<T>) -> Result<(), Error> {
-        let name = self.dict_alloc.bump_str(name)?;
-        self.add_bi_fastr(name, bi)
-    }
-
-    fn add_bi_fastr(&mut self, name: FaStr, bi: WordFunc<T>) -> Result<(), Error> {
-        // Allocate and initialize the dictionary entry
-        let dict_base = self.dict_alloc.bump::<DictionaryEntry<T>>()?;
-        unsafe {
-            dict_base.as_ptr().write(DictionaryEntry {
-                hdr: EntryHeader {
-                    name,
-                    kind: EntryKind::RuntimeBuiltin,
-                    len: 0,
-                    _pd: PhantomData,
-                },
-                func: bi,
-                link: self.run_dict_tail.take(),
-                parameter_field: [],
-            });
-        }
-        self.run_dict_tail = Some(dict_base);
+        let name = self.dict.alloc.bump_str(name)?;
+        self.dict.add_bi_fastr(name, bi)?;
         Ok(())
     }
 
@@ -195,7 +167,7 @@ impl<T> Forth<T> {
     }
 
     fn find_in_dict(&self, fastr: &TmpFaStr<'_>) -> Option<NonNull<DictionaryEntry<T>>> {
-        self.runtime_dict_entries().find(|&de| &de.hdr.name == fastr.deref()).map(NonNull::from)
+        self.dict.entries().find(|&de| &de.hdr.name == fastr.deref()).map(NonNull::from)
     }
 
     pub fn lookup(&self, word: &str) -> Result<Lookup<T>, Error> {
@@ -409,7 +381,7 @@ impl<T> Forth<T> {
 
         // Write a conditional jump, followed by space for a literal
         let literal_cj = self.find_word("2d>2r").ok_or(Error::WordNotInDict)?;
-        self.dict_alloc.bump_write(Word::ptr(literal_cj.as_ptr()))?;
+        self.dict.alloc.bump_write(Word::ptr(literal_cj.as_ptr()))?;
         *len += 1;
 
         let do_start = *len;
@@ -430,9 +402,9 @@ impl<T> Forth<T> {
         let delta = *len - do_start;
         let offset = i32::from(delta + 1).neg();
         let literal_dojmp = self.find_word("(jmp-doloop)").ok_or(Error::WordNotInDict)?;
-        self.dict_alloc
+        self.dict.alloc
             .bump_write(Word::ptr(literal_dojmp.as_ptr()))?;
-        self.dict_alloc.bump_write(Word::data(offset))?;
+        self.dict.alloc.bump_write(Word::data(offset))?;
         *len += 2;
 
         Ok(*len - start)
@@ -443,9 +415,9 @@ impl<T> Forth<T> {
 
         // Write a conditional jump, followed by space for a literal
         let literal_cj = self.find_word("(jump-zero)").ok_or(Error::WordNotInDict)?;
-        self.dict_alloc.bump_write(Word::ptr(literal_cj.as_ptr()))?;
+        self.dict.alloc.bump_write(Word::ptr(literal_cj.as_ptr()))?;
         let cj_offset: &mut i32 = {
-            let cj_offset_word = self.dict_alloc.bump::<Word>()?;
+            let cj_offset_word = self.dict.alloc.bump::<Word>()?;
             unsafe {
                 cj_offset_word.as_ptr().write(Word::data(0));
                 &mut (*cj_offset_word.as_ptr()).data
@@ -488,10 +460,10 @@ impl<T> Forth<T> {
 
         // Write a conditional jump, followed by space for a literal
         let literal_jmp = self.find_word("(jmp)").ok_or(Error::WordNotInDict)?;
-        self.dict_alloc
+        self.dict.alloc
             .bump_write(Word::ptr(literal_jmp.as_ptr()))?;
         let jmp_offset: &mut i32 = {
-            let jmp_offset_word = self.dict_alloc.bump::<Word>()?;
+            let jmp_offset_word = self.dict.alloc.bump::<Word>()?;
             unsafe {
                 jmp_offset_word.as_ptr().write(Word::data(0));
                 &mut (*jmp_offset_word.as_ptr()).data
@@ -536,16 +508,16 @@ impl<T> Forth<T> {
             Lookup::Dict { de } => {
                 // Dictionary items are put into the CFA array directly as
                 // a pointer to the dictionary entry
-                self.dict_alloc.bump_write(Word::ptr(de.as_ptr()))?;
+                self.dict.alloc.bump_write(Word::ptr(de.as_ptr()))?;
                 *len += 1;
             }
             Lookup::Builtin { bi } => {
-                self.dict_alloc.bump_write(Word::ptr(bi.as_ptr()))?;
+                self.dict.alloc.bump_write(Word::ptr(bi.as_ptr()))?;
                 *len += 1;
             }
             #[cfg(feature = "async")]
             Lookup::Async { bi } => {
-                self.dict_alloc.bump_write(Word::ptr(bi.as_ptr()))?;
+                self.dict.alloc.bump_write(Word::ptr(bi.as_ptr()))?;
                 *len += 1;
             }
             #[cfg(feature = "floats")]
@@ -555,9 +527,9 @@ impl<T> Forth<T> {
                 // 1. The address of the `literal()` dictionary item
                 // 2. The value of the literal, as a data word
                 let literal_dict = self.find_word("(literal)").ok_or(Error::WordNotInDict)?;
-                self.dict_alloc
+                self.dict.alloc
                     .bump_write(Word::ptr(literal_dict.as_ptr()))?;
-                self.dict_alloc.bump_write(Word::float(val))?;
+                self.dict.alloc.bump_write(Word::float(val))?;
                 *len += 2;
             }
             Lookup::Literal { val } => {
@@ -566,9 +538,9 @@ impl<T> Forth<T> {
                 // 1. The address of the `literal()` dictionary item
                 // 2. The value of the literal, as a data word
                 let literal_dict = self.find_word("(literal)").ok_or(Error::WordNotInDict)?;
-                self.dict_alloc
+                self.dict.alloc
                     .bump_write(Word::ptr(literal_dict.as_ptr()))?;
-                self.dict_alloc.bump_write(Word::data(val))?;
+                self.dict.alloc.bump_write(Word::data(val))?;
                 *len += 2;
             }
             Lookup::Do => return self.munch_do(len),
@@ -613,14 +585,14 @@ impl<T> Forth<T> {
             u16::try_from(lit_str.as_bytes().len()).replace_err(Error::LiteralStringTooLong)?;
 
         let literal_writestr = self.find_word("(write-str)").ok_or(Error::WordNotInDict)?;
-        self.dict_alloc
+        self.dict.alloc
             .bump_write::<Word>(Word::ptr(literal_writestr.as_ptr()))?;
-        self.dict_alloc
+        self.dict.alloc
             .bump_write::<Word>(Word::data(str_len.into()))?;
         *len += 2;
 
         let start_ptr = self
-            .dict_alloc
+            .dict.alloc
             .bump_u8s(lit_str.as_bytes().len())
             .ok_or(Error::Bump(BumpError::OutOfMemory))?;
 
@@ -643,7 +615,7 @@ impl<T> Forth<T> {
             .input
             .cur_word()
             .ok_or(Error::ColonCompileMissingName)?;
-        let name = self.dict_alloc.bump_str(name)?;
+        let name = self.dict.alloc.bump_str(name)?;
 
         self.input.advance();
         let value = self
@@ -652,8 +624,8 @@ impl<T> Forth<T> {
             .ok_or(Error::ColonCompileMissingName)?;
         let value_i32 = value.parse::<i32>().replace_err(Error::BadLiteral)?;
 
-        let dict_base = self.dict_alloc.bump::<DictionaryEntry<T>>()?;
-        self.dict_alloc.bump_write(Word::data(value_i32))?;
+        let dict_base = self.dict.alloc.bump::<DictionaryEntry<T>>()?;
+        self.dict.alloc.bump_write(Word::data(value_i32))?;
         unsafe {
             dict_base.as_ptr().write(DictionaryEntry {
                 hdr: EntryHeader {
@@ -666,11 +638,11 @@ impl<T> Forth<T> {
                 // Use `find_word`?
                 func: Self::constant,
                 // Don't link until we know we have a "good" entry!
-                link: self.run_dict_tail.take(),
+                link: self.dict.tail.take(),
                 parameter_field: [],
             });
         }
-        self.run_dict_tail = Some(dict_base);
+        self.dict.tail = Some(dict_base);
         Ok(0)
     }
 
@@ -681,10 +653,10 @@ impl<T> Forth<T> {
             .input
             .cur_word()
             .ok_or(Error::ColonCompileMissingName)?;
-        let name = self.dict_alloc.bump_str(name)?;
+        let name = self.dict.alloc.bump_str(name)?;
 
-        let dict_base = self.dict_alloc.bump::<DictionaryEntry<T>>()?;
-        self.dict_alloc.bump_write(Word::data(0))?;
+        let dict_base = self.dict.alloc.bump::<DictionaryEntry<T>>()?;
+        self.dict.alloc.bump_write(Word::data(0))?;
         unsafe {
             dict_base.as_ptr().write(DictionaryEntry {
                 hdr: EntryHeader {
@@ -697,11 +669,11 @@ impl<T> Forth<T> {
                 // Use `find_word`?
                 func: Self::variable,
                 // Don't link until we know we have a "good" entry!
-                link: self.run_dict_tail.take(),
+                link: self.dict.tail.take(),
                 parameter_field: [],
             });
         }
-        self.run_dict_tail = Some(dict_base);
+        self.dict.tail = Some(dict_base);
         Ok(0)
     }
 
@@ -712,7 +684,7 @@ impl<T> Forth<T> {
             .input
             .cur_word()
             .ok_or(Error::ColonCompileMissingName)?;
-        let name = self.dict_alloc.bump_str(name)?;
+        let name = self.dict.alloc.bump_str(name)?;
 
         self.input.advance();
         let count = self
@@ -723,10 +695,10 @@ impl<T> Forth<T> {
             .parse::<NonZeroU16>()
             .replace_err(Error::BadArrayLength)?;
 
-        let dict_base = self.dict_alloc.bump::<DictionaryEntry<T>>()?;
+        let dict_base = self.dict.alloc.bump::<DictionaryEntry<T>>()?;
 
         for _ in 0..u16::from(count_u16) {
-            self.dict_alloc.bump_write(Word::data(0))?;
+            self.dict.alloc.bump_write(Word::data(0))?;
         }
 
         unsafe {
@@ -744,34 +716,11 @@ impl<T> Forth<T> {
                 func: Self::variable,
 
                 // Don't link until we know we have a "good" entry!
-                link: self.run_dict_tail.take(),
+                link: self.dict.tail.take(),
                 parameter_field: [],
             });
         }
-        self.run_dict_tail = Some(dict_base);
+        self.dict.tail = Some(dict_base);
         Ok(0)
-    }
-
-    fn runtime_dict_entries(&self) -> DictEntries<'_, T> {
-        DictEntries { next: self.run_dict_tail, _forth: PhantomData, }
-    }
-}
-
-// === impl DictEntries ===
-
-impl<'dict, T: 'static> Iterator for DictEntries<'dict, T> {
-    type Item = &'dict DictionaryEntry<T>;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let entry = self.next.take()?;
-        let entry = unsafe {
-            // Safety: `self.next` must be a pointer into the VM's dictionary
-            // entries. The caller who constructs a `DictEntries` iterator is
-            // responsible for ensuring this.
-            entry.as_ref()
-        };
-        self.next = entry.link;
-        Some(entry)
     }
 }


### PR DESCRIPTION
This branch adds a method for performing a deep copy of one Forth VM's
dictionary into another VM's dictionary. This will (eventually) be used
to implement the ability to create a new "child" VM from an existing one
that inherits the existing VM's bindings. The deep copy works by
traversing the linked list of entries in the source dictionary and
creating new copies in the target dictionary, which ensures that all
pointers are into the target dictionary, rather than the source. Changes
to either dictionary's bindings will not effect the other dictionary
after the deep copy is performed.

In order to add this method, I've done some refactoring in the
`Dictionary` module:

* I've added a `Dictionary` type, which bundles together a
  `DictionaryBump` with the dictionary's tail pointer (which was
  previously a field on `Forth`).

* Adding the `Dictionary` type allows us to add an iterator over the
  entries in a `Dictionary`. This lets us replace the existing `while`
  loops that manually traverse the linked list with uses of the
  iterator, and is used to implement the deep copy.

* Because the `Dictionary` type knows its tail pointer, we can now add
  an `EntryBuilder` type, which abstracts over adding a new entry with a
  variable number of bump allocations in it. Creating an `EntryBuilder`
  allocates a new entry. Bump allocations for parameters can be
  performed on the builder, and then the builder can be `finish`ed,
  populating the `DictionaryEntry` itself and linking it into the linked
  list. This lets us abstract over code that was previously repeated in
  a number of methods on the `Forth` type, with an interface that
  ensures the entry is correctly populated.

  Note that the `EntryBuilder` type cannot currently be used in the
  implementation of the `:` word. This is because an `EntryBuilder` must
  mutably borrow the dictionary in order to provide a safe abstraction
  that ensures the pointer at which the new entry is written to comes
  from the correct dictionary, but writing a new word's definition
  requires looking up existing words from the dictionary, and this can't
  be done once it's mutably borrowed. I might try and clean this up in a
  subsequent refactor if we decide the `EntryBuilder` abstraction is
  something that's worth having.