### PR TITLE
Pointer handling and dictionary allocation helpers

### DIFF
--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -13,6 +13,7 @@ pub enum BumpError {
 
 #[derive(Debug, Clone, Copy)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum EntryKind {
     StaticBuiltin,
     RuntimeBuiltin,

--- a/src/leakbox.rs
+++ b/src/leakbox.rs
@@ -1,3 +1,4 @@
+use core::ptr::NonNull;
 use std::{
     alloc::{GlobalAlloc, Layout, System},
     cell::UnsafeCell,
@@ -31,6 +32,10 @@ impl<T> LeakBox<T> {
 
     pub fn ptr(&self) -> *mut T {
         self.ptr.cast()
+    }
+
+    pub fn non_null(&self) -> NonNull<T> {
+        NonNull::new(self.ptr.cast::<T>()).unwrap()
     }
 
     pub fn len(&self) -> usize {

--- a/src/leakbox.rs
+++ b/src/leakbox.rs
@@ -34,11 +34,13 @@ impl<T> LeakBox<T> {
         self.ptr.cast()
     }
 
-    pub fn non_null(&self) -> NonNull<T> {
+    pub fn as_non_null(&self) -> NonNull<T> {
         #[cfg(debug_assertions)]
-        NonNull::new(self.ptr.cast::<T>()).unwrap()
+        let res = NonNull::new(self.ptr.cast::<T>()).unwrap();
         #[cfg(not(debug_assertions))]
-        NonNull::new_unchecked(self.ptr.cast::<T>())
+        let res = unsafe { NonNull::new_unchecked(self.ptr.cast::<T>()) };
+
+        res
     }
 
     pub fn len(&self) -> usize {

--- a/src/leakbox.rs
+++ b/src/leakbox.rs
@@ -35,7 +35,10 @@ impl<T> LeakBox<T> {
     }
 
     pub fn non_null(&self) -> NonNull<T> {
+        #[cfg(debug_assertions)]
         NonNull::new(self.ptr.cast::<T>()).unwrap()
+        #[cfg(not(debug_assertions))]
+        NonNull::new_unchecked(self.ptr.cast::<T>())
     }
 
     pub fn len(&self) -> usize {

--- a/src/word.rs
+++ b/src/word.rs
@@ -11,6 +11,7 @@ pub union Word {
     pub data: i32,
     #[cfg(feature = "floats")]
     pub float: f32,
+    pub ptr_data: isize,
     pub ptr: *mut (),
 }
 
@@ -69,6 +70,15 @@ impl Word {
         let mut mu_word: MaybeUninit<Word> = MaybeUninit::zeroed();
         unsafe {
             addr_of_mut!((*mu_word.as_mut_ptr()).ptr).write(ptr.cast());
+            mu_word.assume_init()
+        }
+    }
+
+    #[inline]
+    pub fn ptr_data(ptr_data: isize) -> Self {
+        let mut mu_word: MaybeUninit<Word> = MaybeUninit::zeroed();
+        unsafe {
+            addr_of_mut!((*mu_word.as_mut_ptr()).ptr_data).write(ptr_data);
             mu_word.assume_init()
         }
     }


### PR DESCRIPTION
These are the "non-`disk`" changes made for #2, without the actual "add the disk" support.

I'm opening this as a PR to hopefully allow @hawkw to merge it into her branches while I'm still working on disk branch.

Uncontroversial changes:

* Makes EntryKind non-exhaustive - could be used for robustness checking
* Adds a single method to allocation a dictionary entry, used to remove some copy/paste code
* adds `b@` and `b!` operators for byte-aligned (instead of cell-aligned) load/stores

Potentially controversial changes:

* Adds a `ptr_data: isize` union variant to the cell type, to be used when mixing "i32" data from the stack with "ptr" data from the stack
* ONLY `add` and `sub` actually use the `ptr_data` variant

At some point, we might want to pass and declare which operators ARE "pointer safe", and which ones aren't, or add specific ptr-safe operators. That being said, I'm not sure whether any operations OTHER than add or sub on a pointer are likely to be meaningful.