### PR TITLE
testutil: print input and output during tests

### DIFF
--- a/src/testutil/mod.rs
+++ b/src/testutil/mod.rs
@@ -133,9 +133,9 @@ where
     D: for<'forth> crate::dictionary::AsyncBuiltins<'forth, T>,
 {
     let tokd = tokenize(contents, false).unwrap();
-    for Step { input, output: outcome } in tokd.steps.iter() {
+    for Step { ref input, output: ref outcome } in tokd.steps {
         println!("> {input}");
-        forth.input_mut().fill(&input).unwrap();
+        forth.input_mut().fill(input).unwrap();
         let res = futures::executor::block_on(forth.process_line());
         check_output(res, outcome, forth.output().as_str());
         forth.output_mut().clear();
@@ -170,9 +170,9 @@ fn check_output(res: Result<(), Error>, outcome: &Outcome, output: &str) {
 //
 // Panics on any mismatch
 fn blocking_steps_with<T>(steps: &[Step], forth: &mut Forth<T>) {
-    for Step { input, output: outcome } in steps.into_iter() {
+    for Step { input, output: outcome } in steps {
         println!("> {input}");
-        forth.input.fill(&input).unwrap();
+        forth.input.fill(input).unwrap();
         let res = forth.process_line();
         check_output(res, outcome, forth.output.as_str());
         forth.output.clear();

--- a/src/testutil/mod.rs
+++ b/src/testutil/mod.rs
@@ -134,6 +134,7 @@ where
 {
     let tokd = tokenize(contents, false).unwrap();
     for Step { ref input, output: ref outcome } in tokd.steps {
+        #[cfg(not(miri))]
         println!("> {input}");
         forth.input_mut().fill(input).unwrap();
         let res = futures::executor::block_on(forth.process_line());
@@ -143,6 +144,7 @@ where
 }
 
 fn check_output(res: Result<(), Error>, outcome: &Outcome, output: &str) {
+    #[cfg(not(miri))]
     println!("< {output}");
     match (res, outcome) {
         (Ok(()), Outcome::OkAnyOutput) => {}
@@ -171,6 +173,7 @@ fn check_output(res: Result<(), Error>, outcome: &Outcome, output: &str) {
 // Panics on any mismatch
 fn blocking_steps_with<T>(steps: &[Step], forth: &mut Forth<T>) {
     for Step { input, output: outcome } in steps {
+        #[cfg(not(miri))]
         println!("> {input}");
         forth.input.fill(input).unwrap();
         let res = forth.process_line();

--- a/src/testutil/mod.rs
+++ b/src/testutil/mod.rs
@@ -134,6 +134,7 @@ where
 {
     let tokd = tokenize(contents, false).unwrap();
     for Step { input, output: outcome } in tokd.steps.iter() {
+        println!("> {input}");
         forth.input_mut().fill(&input).unwrap();
         let res = futures::executor::block_on(forth.process_line());
         check_output(res, outcome, forth.output().as_str());
@@ -142,6 +143,7 @@ where
 }
 
 fn check_output(res: Result<(), Error>, outcome: &Outcome, output: &str) {
+    println!("< {output}");
     match (res, outcome) {
         (Ok(()), Outcome::OkAnyOutput) => {}
         (Ok(()), Outcome::OkWithOutput(exp)) => {
@@ -169,6 +171,7 @@ fn check_output(res: Result<(), Error>, outcome: &Outcome, output: &str) {
 // Panics on any mismatch
 fn blocking_steps_with<T>(steps: &[Step], forth: &mut Forth<T>) {
     for Step { input, output: outcome } in steps.into_iter() {
+        println!("> {input}");
         forth.input.fill(&input).unwrap();
         let res = forth.process_line();
         check_output(res, outcome, forth.output.as_str());


### PR DESCRIPTION
The current test utilities are somewhat harder to debug than the previous `test_lines` functions they replaced, as they do not print the input and output of the forth VM during the test. This means that when an assertion failed, it's not clear what input line was executed immediately before the assertion failed. This branch changes the new test utils to print each input and output line as the test runs, the way the previous tests did.

Alternatively, I could change these tests to only print the line of input immediately before the failure, but I thought it was potentially useful to get every line...