### PR TITLE
Mark `dispatch_async` parameter as `'static`, to make async usage easier

### DIFF
--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -237,10 +237,13 @@ pub trait AsyncBuiltins<'forth, T: 'static> {
     /// for each builtin name. See [the `AsyncBuiltin` trait's
     /// documentation][impling] for details on implementing this method.
     ///
+    /// The `id` parameter is `'static`, as we will only resolve function names
+    /// from the provided [`Self::BUILTINS`], which must be `'static`.
+    ///
     /// [`Future`]: core::future::Future
     /// [`match`]: https://doc.rust-lang.org/stable/std/keyword.match.html
     /// [impling]: #implementing-async-builtins
-    fn dispatch_async(&self, id: &FaStr, forth: &'forth mut crate::Forth<T>) -> Self::Future;
+    fn dispatch_async(&self, id: &'static FaStr, forth: &'forth mut crate::Forth<T>) -> Self::Future;
 }
 
 impl<T: 'static> DictionaryEntry<T> {


### PR DESCRIPTION
I noticed in [some prototyping](https://github.com/tosc-rs/mnemos/blob/668c40ea1492052f227e243c3559b639d3f18f7f/source/kernel/src/forth.rs#L188-L224) that the lack of the `'static` lifetime bound made it impossible to do the matching in an async context.

I believe this change is sufficient to allow that, and should be sound, as all name resolution will point to the `'static` AsyncBuiltins provided by the trait implementation.