### PR TITLE
add `Send` and `Sync` impls for `Forth`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,12 +268,26 @@ pub mod test {
         contents: Vec<i32>,
     }
 
+    fn assert_send<T: Send>() {}
+
     #[test]
     fn sizes() {
         use core::mem::{align_of, size_of};
         assert_eq!(5 * size_of::<usize>(), size_of::<DictionaryEntry<()>>());
         assert_eq!(5 * size_of::<usize>(), size_of::<DictionaryEntry<()>>());
         assert_eq!(1 * size_of::<usize>(), align_of::<Word>());
+    }
+
+    #[test]
+    fn is_send() {
+        assert_send::<Forth<()>>();
+    }
+
+    #[test]
+    #[cfg(feature = "async")]
+    fn async_forth_is_send() {
+        use crate::AsyncForth;
+        assert_send::<AsyncForth<(), ()>>();
     }
 
     #[test]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -754,3 +754,19 @@ impl<T> Forth<T> {
         Ok(0)
     }
 }
+
+/// # Safety
+///
+/// A `Forth` VM contains raw pointers. However, these raw pointers point into
+/// regions which are exclusively owned by the `Forth` VM, and they are only
+/// mutably dereferenced by methods which take ownership over the Forth VM. The
+/// Constructing a new VM via `Forth::new` is unsafe, as the caller is
+/// responsible for ensuring that the pointed memory regions are exclusively
+/// owned by the `Forth` VM and that they live at least as long as the VM does,
+/// but as long as those invariants are upheld, the VM may be shared across
+/// thread boundaries.
+// TODO(eliza): it would be nicer if there was a way to have a version of
+// `LBForth` or something that bundles a `Forth` VM together with its owned
+// buffers, but without requiring `liballoc`...idk what that would look like.
+unsafe impl<T: Send> Send for Forth<T> {}
+unsafe impl<T: Sync> Sync for Forth<T> {}


### PR DESCRIPTION
The `Forth` and `AsyncForth` types are `!Send`. This makes them
difficult to use with the latest `maitake`, which requires futures be
`Send` in order to be spawned as a task.

These types are `!Send` because they contain raw pointers to the buffer
regions provided when the VM is constructed. I think they can be made
`Send` (and `Sync`), based on the rationale that the unsafety is in the
invariants of calling `Forth::new` --- if the VM is sent across a thread
boundary, the buffer regions provided to `Forth::new` must travel with
it. Thus, `Forth::new` should still be unsafe, but the VM *can* be
`Send` if `Forth::new`'s invariants are upheld.

Alternatively, we could solve this by wrapping `Forth` in a type which
has ownership over the buffers plus a deallocation callback for those
buffers, instead. This would be similar to `LBForth` but without the use
of `Box`. That type could always be `Send` and `Sync`, without the
caveats I mentioned above.

@jamesmunns what do you think?